### PR TITLE
Handle version line formatting variations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ export class ChangelogParser {
 	private readonly CHANGE_TYPE_PATTERN = /### ([A-Za-z ]+)/;
 
 	private isVersionLine(line: string): boolean {
-		return line.startsWith("## [");
+		// Support version headings starting with either '## [' or '### ['
+		return /^#{2,3}\s*\[/.test(line);
 	}
 
 	private parseVersionLine(line: string) {


### PR DESCRIPTION
Update `isVersionLine` to recognize version headings starting with "## [" or "### [" to improve changelog parsing flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba681c5b-5786-4682-8375-64ce73eab738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba681c5b-5786-4682-8375-64ce73eab738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

